### PR TITLE
Adding box-shadow to 'Portfolio' Github cards

### DIFF
--- a/src/styles/modules/_myPortfolio.module.scss
+++ b/src/styles/modules/_myPortfolio.module.scss
@@ -13,6 +13,7 @@
       height: 130px;
       border: 5px solid #003b46;
       border-radius: 6px;
+      box-shadow: 10px 10px 15px -15px rgba(0,0,0,0.95);
     }
 
     object {


### PR DESCRIPTION
Just a box-shadow feature to enhance 'Portfolio' cards beauty.